### PR TITLE
modif loss and acc display

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -19,7 +19,7 @@ def train_triplet(train_loader,model,criterion,optimizer,
         output = model(input1,input2)
 
         loss = criterion(output)
-        meters['loss'].update(loss.data.item(), n=batch_size)
+        meters['loss'].update(loss.data.item(), n=1)
         
         optimizer.zero_grad()
         loss.backward()
@@ -42,7 +42,7 @@ def train_triplet(train_loader,model,criterion,optimizer,
                   'Data {data_time.val:.3f} ({data_time.avg:.3f})\t'
                   'LR {lr.val:.2e}\t'
                   'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
-                  'Acc_Max {acc_max.val:.3f} ({acc_max.avg:.3f})'.format(
+                  'Acc_Max {acc_max.avg:.3f} ({acc_max.val:.3f})'.format(
                    epoch, i, len(train_loader), batch_time=meters['batch_time'],
                    data_time=meters['data_time'], lr=meters_params['learning_rate'], loss=meters['loss'], acc_max=meters['acc_max']))
 
@@ -56,14 +56,12 @@ def val_triplet(val_loader,model,criterion,
     meters = logger.reset_meters('val')
 
     for i, (input1, input2) in enumerate(val_loader):
-        batch_size = input1.shape[0]
-        
         input1 = input1.to(device)
         input2 = input2.to(device)
         output = model(input1,input2)
 
         loss = criterion(output)
-        meters['loss'].update(loss.data.item(), n=batch_size)
+        meters['loss'].update(loss.data.item(), n=1)
     
         if eval_score is not None:
             np_out = output.cpu().detach().numpy()
@@ -74,7 +72,7 @@ def val_triplet(val_loader,model,criterion,
         if i % print_freq == 0:
             print('Validation set, epoch: [{0}][{1}/{2}]\t'
                     'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
-                    'Acc {acc.val:.3f} ({acc.avg:.3f})'.format(
+                    'Acc {acc.avg:.3f} ({acc.val:.3f})'.format(
                     epoch, i, len(val_loader), loss=meters['loss'], acc=meters['acc_la']))
 
     logger.log_meters('val', n=epoch)


### PR DESCRIPTION
resolve #7

I agree with you for the loss

For Acc, I modified the code so that you have the current accuracy and the number of right predictions in (). In the training, the acc should increase inside an epoch as the algorithm gets better and better... For the validation, the acc should be stationary.

For your last point, I am not sure to understand your point. What I want is the average loss or accuracy over an epoch (not over a batch) which is the last loss and acc displayed in an epoch. This is why I am resetting at each start of a new epoch.

Hope this is clear?

Thanks! 