### PR TITLE
Modif architecture RegularBlock

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -19,7 +19,7 @@ def train_triplet(train_loader,model,criterion,optimizer,
         output = model(input1,input2)
 
         loss = criterion(output)
-        meters['loss'].update(loss.data.item(), n=batch_size)
+        meters['loss'].update(loss.data.item(), n=1)
         
         optimizer.zero_grad()
         loss.backward()
@@ -42,7 +42,7 @@ def train_triplet(train_loader,model,criterion,optimizer,
                   'Data {data_time.val:.3f} ({data_time.avg:.3f})\t'
                   'LR {lr.val:.2e}\t'
                   'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
-                  'Acc_Max {acc_max.val:.3f} ({acc_max.avg:.3f})'.format(
+                  'Acc_Max {acc_max.avg:.3f} ({acc_max.val:.3f})'.format(
                    epoch, i, len(train_loader), batch_time=meters['batch_time'],
                    data_time=meters['data_time'], lr=meters_params['learning_rate'], loss=meters['loss'], acc_max=meters['acc_max']))
 
@@ -56,14 +56,12 @@ def val_triplet(val_loader,model,criterion,
     meters = logger.reset_meters('val')
 
     for i, (input1, input2) in enumerate(val_loader):
-        batch_size = input1.shape[0]
-        
         input1 = input1.to(device)
         input2 = input2.to(device)
         output = model(input1,input2)
 
         loss = criterion(output)
-        meters['loss'].update(loss.data.item(), n=batch_size)
+        meters['loss'].update(loss.data.item(), n=1)
     
         if eval_score is not None:
             np_out = output.cpu().detach().numpy()
@@ -74,7 +72,7 @@ def val_triplet(val_loader,model,criterion,
         if i % print_freq == 0:
             print('Validation set, epoch: [{0}][{1}/{2}]\t'
                     'Loss {loss.val:.4f} ({loss.avg:.4f})\t'
-                    'Acc {acc.val:.3f} ({acc.avg:.3f})'.format(
+                    'Acc {acc.avg:.3f} ({acc.val:.3f})'.format(
                     epoch, i, len(val_loader), loss=meters['loss'], acc=meters['acc_la']))
 
     logger.log_meters('val', n=epoch)


### PR DESCRIPTION
To prevent the network to be trapped in a bad minima outputing an embedding of zeros for all nodes, I added a last convolutional layer at the end of mlp3 so that there is no more Relu activation at the end of the regular block. Empirically it seems to work quite well! I tested for regular networks with noise 0.25 after 10 epoch acc 0.04 with a decreasing loss...